### PR TITLE
Add `type=code` to GitHub search query

### DIFF
--- a/gh/manifest.json
+++ b/gh/manifest.json
@@ -23,7 +23,7 @@
 		"search_provider": {
 			"name": "GitHub",
       "keyword": "@gh",
-			"search_url": "https://github.com/search?q={searchTerms}"
+			"search_url": "https://github.com/search?type=code&q={searchTerms}"
 		}
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> @dannycolin: I wasn't able to open an issue on this repository.
> I figured this would be a good alternative to start a discussion.
> Happy to take a different approach here if you'd prefer (since this would
> technically be a breaking change, though that's probably GitHub's fault).

Today, GitHub defaults to something more like `type=repositories`, which is not particularly useful when searching GitHub. I imagine most folks want to search for code (I certainly do!)